### PR TITLE
bruteforcer: activate again the screenshots saving

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1021,46 +1021,23 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 
 	// done with drawing the game stuff, good moment to save a screenshot
 	if (Core::ch_bruteforce && Core::ch_tomarFoto > 0)
-	{
-		//if (Core::ch_tomarFoto == 1){
-			//s_bScreenshot = true;
-			//s_sScreenshotName = File::GetUserPath(D_SCREENSHOTS_IDX) + Core::ch_title_id + "/" + std::to_string(Core::ch_codigoactual) + "_" + Core::ch_map[Core::ch_codigoactual] + "_" + Core::ch_code + ".png";
-			 
-			std::string s_sAux = std::to_string(Core::ch_codigoactual) + "," + Core::ch_map[Core::ch_codigoactual] +
-				"," + Core::ch_code + "," + std::to_string(stats.thisFrame.numPrims) + "," + std::to_string(stats.thisFrame.numDrawCalls) + "," + std::to_string(Core::ch_tomarFoto);
-			std::ofstream myfile;
-			myfile.open(File::GetUserPath(D_SCREENSHOTS_IDX) + Core::ch_title_id + "/bruteforce.csv" , std::ios_base::app);
-			myfile << s_sAux << "\n";
-			myfile.close();
-			if (Core::ch_tomarFoto == 1){
-				Core::ch_cicles_without_snapshot = 0;
-				Core::ch_cacheo_pasado = true;
-				Core::ch_next_code = true; //TODO next code quitar de aqui
-			}
-		//}
-		Core::ch_tomarFoto -= 1;
-	}
-	/*
-	if (Core::ch_bruteforce && Core::ch_tomarFoto>0)
-	{
-		if (Core::ch_tomarFoto == 1)
-		{
-			Core::ch_tomarFoto = 0;
-			std::lock_guard<std::mutex> lk(s_criticalScreenshot);
-			std::ostringstream s;
-			s << Core::ch_codigoactual;
-
+	{								 
+		std::string s_sAux = std::to_string(Core::ch_codigoactual) + "," + Core::ch_map[Core::ch_codigoactual] +
+			"," + Core::ch_code + "," + std::to_string(stats.thisFrame.numPrims) + "," + std::to_string(stats.thisFrame.numDrawCalls) + "," + std::to_string(Core::ch_tomarFoto);
+		std::ofstream myfile;
+		myfile.open(File::GetUserPath(D_SCREENSHOTS_IDX) + Core::ch_title_id + "/bruteforce.csv" , std::ios_base::app);
+		myfile << s_sAux << "\n";
+		myfile.close();
+		if (Core::ch_tomarFoto == 1){
 			s_bScreenshot = true;
-			s_sScreenshotName = File::GetUserPath(D_SCREENSHOTS_IDX) + Core::ch_title_id + "/" + std::to_string(Core::ch_codigoactual) + "_"+ Core::ch_map[Core::ch_codigoactual] + "_"+ Core::ch_code +".png";
+			s_sScreenshotName = File::GetUserPath(D_SCREENSHOTS_IDX) + Core::ch_title_id + "/" + std::to_string(Core::ch_codigoactual) + "_" + Core::ch_map[Core::ch_codigoactual] + "_" + Core::ch_code + ".png";
 			Core::ch_cicles_without_snapshot = 0;
 			Core::ch_cacheo_pasado = true;
-			Core::ch_next_code = true; //TODO next code quitar de aqui
+			Core::ch_next_code = true; 
 		}
-		else
-		{
-			Core::ch_tomarFoto -= 1;
-		}
-	}*/
+		
+		Core::ch_tomarFoto -= 1;
+	}	
 
 	if (s_bScreenshot && !g_ActiveConfig.bAsynchronousTimewarp)
 	{


### PR DESCRIPTION
numDrawCalls from stats gives a lots of false positives, the screenshots
keeps helping to find positives.