### PR TITLE
Implement relocations for RPL/RPX executables

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -377,7 +377,10 @@ bool CBoot::BootUp()
 		else // Poor man's bootup
 		{
 			Load_FST(elfWii);
-			Boot_ELF(_StartupPara.m_strFilename);
+			if (!elfWiiU)
+				Boot_ELF(_StartupPara.m_strFilename);
+			else
+				Boot_RPX(_StartupPara.m_strFilename);
 		}
 		UpdateDebugger_MapLoaded();
 		Dolphin_Debugger::AddAutoBreakpoints();

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -51,6 +51,7 @@ private:
 
 	static bool LoadMapFromFilename();
 	static bool Boot_ELF(const std::string& filename);
+	static bool Boot_RPX(const std::string& filename);
 	static bool Boot_WiiWAD(const std::string& filename);
 
 	static bool EmulatedBS2_GC();

--- a/Source/Core/Core/Boot/Boot_ELF.cpp
+++ b/Source/Core/Core/Boot/Boot_ELF.cpp
@@ -121,7 +121,7 @@ bool CBoot::Boot_ELF(const std::string& filename)
 	}
 
 	ElfReader reader(mem.data());
-	reader.LoadInto(0x80000000);
+	reader.LoadInto(0x80100000);
 	if (!reader.LoadSymbols())
 	{
 		if (LoadMapFromFilename())

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "Core/Boot/ElfTypes.h"
 
 enum KnownElfTypes
@@ -36,6 +38,16 @@ private:
 	u32 loaded_length;
 
 public:
+
+	class RPLExportsMap {
+	public:
+		std::unordered_map<std::string, std::unordered_map<std::string, u32> > map;
+		void AddExport(std::string const& libraryname, std::string const& symbolname, u32 symbol)
+		{
+			map[libraryname][symbolname] = symbol;
+		}
+	};
+
 	ElfReader(void *ptr);
 	~ElfReader();
 
@@ -73,10 +85,11 @@ public:
 
 	// true for Wii U .rpx or .rpl files
 	bool is_rpx = false;
-	bool Relocate();
+	bool Relocate(RPLExportsMap& exports);
 	std::vector<std::string> GetDependencies();
 	u32 GetLoadedLength()
 	{
 		return loaded_length;
 	}
+	bool LoadExports(std::string const& libraryname, RPLExportsMap& map);
 };

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -33,6 +33,7 @@ private:
 	// an array of pointers to decompressed sections
 	u8 **decompressed;
 	u32 m_number_of_sections;
+	u32 base_address;
 
 public:
 	ElfReader(void *ptr);
@@ -72,4 +73,5 @@ public:
 
 	// true for Wii U .rpx or .rpl files
 	bool is_rpx = false;
+	bool Relocate();
 };

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -33,7 +33,7 @@ private:
 	// an array of pointers to decompressed sections
 	u8 **decompressed;
 	u32 m_number_of_sections;
-	u32 base_address;
+	u32 loaded_length;
 
 public:
 	ElfReader(void *ptr);
@@ -74,4 +74,9 @@ public:
 	// true for Wii U .rpx or .rpl files
 	bool is_rpx = false;
 	bool Relocate();
+	std::vector<std::string> GetDependencies();
+	u32 GetLoadedLength()
+	{
+		return loaded_length;
+	}
 };

--- a/Source/Core/Core/Boot/ElfTypes.h
+++ b/Source/Core/Core/Boot/ElfTypes.h
@@ -179,6 +179,8 @@ enum ElfSectionFlags
 #define	R_PPC_SECTOFF_HI	35
 #define	R_PPC_SECTOFF_HA	36
 
+#define R_PPC_EMB_SDA21		109
+
 // Segment types
 #define PT_NULL             0
 #define PT_LOAD             1

--- a/Source/Core/Core/Boot/ElfTypes.h
+++ b/Source/Core/Core/Boot/ElfTypes.h
@@ -141,6 +141,44 @@ enum ElfSectionFlags
 #define R_386_GOTOFF    9
 #define R_386_GOTPC    10
 
+#define	R_PPC_NONE		0	/* No relocation. */
+#define	R_PPC_ADDR32		1
+#define	R_PPC_ADDR24		2
+#define	R_PPC_ADDR16		3
+#define	R_PPC_ADDR16_LO		4
+#define	R_PPC_ADDR16_HI		5
+#define	R_PPC_ADDR16_HA		6
+#define	R_PPC_ADDR14		7
+#define	R_PPC_ADDR14_BRTAKEN	8
+#define	R_PPC_ADDR14_BRNTAKEN	9
+#define	R_PPC_REL24		10
+#define	R_PPC_REL14		11
+#define	R_PPC_REL14_BRTAKEN	12
+#define	R_PPC_REL14_BRNTAKEN	13
+#define	R_PPC_GOT16		14
+#define	R_PPC_GOT16_LO		15
+#define	R_PPC_GOT16_HI		16
+#define	R_PPC_GOT16_HA		17
+#define	R_PPC_PLTREL24		18
+#define	R_PPC_COPY		19
+#define	R_PPC_GLOB_DAT		20
+#define	R_PPC_JMP_SLOT		21
+#define	R_PPC_RELATIVE		22
+#define	R_PPC_LOCAL24PC		23
+#define	R_PPC_UADDR32		24
+#define	R_PPC_UADDR16		25
+#define	R_PPC_REL32		26
+#define	R_PPC_PLT32		27
+#define	R_PPC_PLTREL32		28
+#define	R_PPC_PLT16_LO		29
+#define	R_PPC_PLT16_HI		30
+#define	R_PPC_PLT16_HA		31
+#define	R_PPC_SDAREL16		32
+#define	R_PPC_SECTOFF		33
+#define	R_PPC_SECTOFF_LO	34
+#define	R_PPC_SECTOFF_HI	35
+#define	R_PPC_SECTOFF_HA	36
+
 // Segment types
 #define PT_NULL             0
 #define PT_LOAD             1


### PR DESCRIPTION
Relocate RPX and RPL executables after loading. Currently relocation happens immediately after load; in the future, dependencies should be resolved between load and relocation.

Other changes to support relocation:

- move load address of relocatable executables 1 MB up to avoid conflict with automatic patch at 0x80000004
- Ignore RPL sections with address above 0xc0000000 such as the imports table
- removed check that prevents RPXes from being relocated: all RPXes are relocatable
- Subtract RPL default base of 0x2000000 when calculating base address
- Fix symbol offset: add base address instead of section address