### PR TITLE
Direct3D Mirror Now Works 0.7/8 SDK

### DIFF
--- a/Source/Core/VideoBackends/D3D/VRD3D.cpp
+++ b/Source/Core/VideoBackends/D3D/VRD3D.cpp
@@ -79,6 +79,7 @@ OculusTexture *pEyeRenderTexture[2];
 ovrRecti       eyeRenderViewport[2];
 ovrTexture    *mirrorTexture = nullptr;
 int mirror_width = 0, mirror_height = 0;
+D3D11_TEXTURE2D_DESC texdesc = {};
 #endif
 
 #endif
@@ -168,7 +169,6 @@ void RecreateMirrorTextureIfNeeded()
 		if (!g_ActiveConfig.bNoMirrorToWindow)
 		{
 			// Create a mirror to see on the monitor.
-			D3D11_TEXTURE2D_DESC texdesc;
 			texdesc.ArraySize = 1;
 			texdesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
 			texdesc.Width = w;


### PR DESCRIPTION
BUG: Mirror gamma darker than HMD, assuming this has something to do with the SRGB Colour Space... HMD is not affected as far as i know in both 0.7 and 0.8 Runtimes... unsure of 0.6 at this point